### PR TITLE
[fix] BookingDetail Webclient 중복호출 및 code refactoring

### DIFF
--- a/src/main/java/com/pyokemon/bff/dto/external/VenueDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/VenueDto.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class VenueDto {
     private Long venueId;
-    private String name;
+    private String venueName;
 }

--- a/src/main/java/com/pyokemon/bff/dto/response/BookingDetailResponse.java
+++ b/src/main/java/com/pyokemon/bff/dto/response/BookingDetailResponse.java
@@ -1,12 +1,12 @@
 package com.pyokemon.bff.dto.response;
 
-import com.pyokemon.bff.dto.BookingStatus;
-import com.pyokemon.bff.dto.PaymentStatus;
-import lombok.Data;
 
+import lombok.Data;
+import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Data
+@Builder
 public class BookingDetailResponse {
     private Long bookingId;
     private String status;
@@ -17,11 +17,13 @@ public class BookingDetailResponse {
     private PaymentInfo payment;
 
     @Data
+    @Builder
     public static class UserInfo {
         private String name;
     }
 
     @Data
+    @Builder
     public static class EventInfo {
         private String title;
         private String thumbnailUrl;
@@ -29,12 +31,14 @@ public class BookingDetailResponse {
         private VenueInfo venue;
 
         @Data
+        @Builder
         public static class VenueInfo {
             private String name;
         }
     }
 
     @Data
+    @Builder
     public static class SeatInfo {
         private String className;
         private Integer floor;
@@ -43,6 +47,7 @@ public class BookingDetailResponse {
     }
 
     @Data
+    @Builder
     public static class PaymentInfo {
         private String method;
         private String status;

--- a/src/main/java/com/pyokemon/bff/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/pyokemon/bff/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.pyokemon.bff.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/pyokemon/bff/service/BookingDetailService.java
+++ b/src/main/java/com/pyokemon/bff/service/BookingDetailService.java
@@ -2,53 +2,40 @@ package com.pyokemon.bff.service;
 
 import com.pyokemon.bff.dto.response.BookingDetailResponse;
 import com.pyokemon.bff.dto.external.*;
+import com.pyokemon.bff.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class BookingDetailService {
+
     private final WebClient bookingServiceWebClient;
     private final WebClient eventServiceWebClient;
     private final WebClient accountServiceWebClient;
     private final WebClient paymentServiceWebClient;
 
     public Mono<BookingDetailResponse> getBookingDetail(Long bookingId, Long accountId) {
-        // 1단계: booking-service와 account-service 호출
-        Mono<BookingDto> bookingMono = bookingServiceWebClient.get()
-                .uri("/booking/api/bookings/bff/{bookingId}", bookingId)
-                .retrieve()
-                .bodyToMono(BookingDto.class)
-                .filter(booking -> booking.getAccountId().equals(accountId))
-                .switchIfEmpty(Mono.error(new IllegalArgumentException("Booking not found or unauthorized")));
+        log.info("Booking detail request received for bookingId: {} and accountId: {}", bookingId, accountId);
 
-        Mono<AccountDto> accountMono = accountServiceWebClient.get()
-                .uri("/account/api/users/{accountId}", accountId)
-                .retrieve()
-                .bodyToMono(AccountDto.class);
+        // 1단계: booking-service와 account-service 호출 (병렬)
+        Mono<BookingDto> bookingMono = fetchBooking(bookingId, accountId);
+        Mono<AccountDto> accountMono = fetchAccount(accountId);
 
         return Mono.zip(bookingMono, accountMono)
                 .flatMap(tuple -> {
                     BookingDto booking = tuple.getT1();
                     AccountDto account = tuple.getT2();
 
-                    // 2단계: event-service (schedule, seat), payment-service 호출
-                    Mono<EventScheduleDto> scheduleMono = eventServiceWebClient.get()
-                            .uri("/event/api/event-schedules/{eventScheduleId}", booking.getEventScheduleId())
-                            .retrieve()
-                            .bodyToMono(EventScheduleDto.class);
-
-                    Mono<PaymentDto> paymentMono = paymentServiceWebClient.get()
-                            .uri("/payment/api/payments/{paymentId}", booking.getPaymentId())
-                            .retrieve()
-                            .bodyToMono(PaymentDto.class);
-
-                    Mono<SeatDto> seatMono = eventServiceWebClient.get()
-                            .uri("/event/api/seats/{seatId}", booking.getSeatId())
-                            .retrieve()
-                            .bodyToMono(SeatDto.class);
+                    // 2단계: event-service (schedule, seat) 및 payment-service 호출 (병렬)
+                    Mono<EventScheduleDto> scheduleMono = fetchEventSchedule(booking.getEventScheduleId());
+                    Mono<PaymentDto> paymentMono = fetchPayment(booking.getPaymentId());
+                    Mono<SeatDto> seatMono = fetchSeat(booking.getSeatId());
 
                     return Mono.zip(scheduleMono, paymentMono, seatMono)
                             .flatMap(t -> {
@@ -56,59 +43,108 @@ public class BookingDetailService {
                                 PaymentDto payment = t.getT2();
                                 SeatDto seat = t.getT3();
 
-                                // 3단계: event-service (event, venue, seat class) 호출
-                                Mono<EventDto> eventMono = eventServiceWebClient.get()
-                                        .uri("/event/api/bff/events/{eventId}", schedule.getEventId())
-                                        .retrieve()
-                                        .bodyToMono(EventDto.class);
-
-                                Mono<VenueDto> venueMono = eventServiceWebClient.get()
-                                        .uri("/event/api/venues/{venueId}", schedule.getVenueId())
-                                        .retrieve()
-                                        .bodyToMono(VenueDto.class);
-
-                                Mono<SeatClassDto> seatClassMono = eventServiceWebClient.get()
-                                        .uri("/event/api/seat-classes/{seatClassId}", seat.getSeatClassId())
-                                        .retrieve()
-                                        .bodyToMono(SeatClassDto.class);
+                                // 3단계: event-service (event, venue, seat class) 호출 (병렬)
+                                Mono<EventDto> eventMono = fetchEvent(schedule.getEventId());
+                                Mono<VenueDto> venueMono = fetchVenue(schedule.getVenueId());
+                                Mono<SeatClassDto> seatClassMono = fetchSeatClass(seat.getSeatClassId());
 
                                 return Mono.zip(eventMono, venueMono, seatClassMono)
-                                        .map(t2 -> {
-                                            BookingDetailResponse response = new BookingDetailResponse();
-                                            response.setBookingId(booking.getBookingId());
-                                            response.setStatus(booking.getStatus().getDisplayValue());
-                                            response.setCreatedAt(booking.getUpdatedAt());
-
-                                            BookingDetailResponse.UserInfo user = new BookingDetailResponse.UserInfo();
-                                            user.setName(account.getName());
-                                            response.setUser(user);
-
-                                            BookingDetailResponse.EventInfo eventInfo = new BookingDetailResponse.EventInfo();
-                                            eventInfo.setTitle(t2.getT1().getTitle());
-                                            eventInfo.setThumbnailUrl(t2.getT1().getThumbnailUrl());
-                                            eventInfo.setEventDate(schedule.getEventDate().toLocalDate().toString());
-                                            BookingDetailResponse.EventInfo.VenueInfo venueInfo = new BookingDetailResponse.EventInfo.VenueInfo();
-                                            venueInfo.setName(t2.getT2().getName());
-                                            eventInfo.setVenue(venueInfo);
-                                            response.setEvent(eventInfo);
-
-                                            BookingDetailResponse.SeatInfo seatInfo = new BookingDetailResponse.SeatInfo();
-                                            seatInfo.setClassName(t2.getT3().getClassName());
-                                            seatInfo.setFloor(seat.getFloor());
-                                            seatInfo.setRow(seat.getRow());
-                                            seatInfo.setCol(seat.getCol());
-                                            response.setSeat(seatInfo);
-
-                                            BookingDetailResponse.PaymentInfo paymentInfo = new BookingDetailResponse.PaymentInfo();
-                                            paymentInfo.setMethod(payment.getMethod());
-                                            paymentInfo.setStatus(payment.getStatus().getDisplayValue());
-                                            paymentInfo.setPaidAt(payment.getUpdatedAt().toString());
-                                            paymentInfo.setAmount(payment.getAmount());
-                                            response.setPayment(paymentInfo);
-
-                                            return response;
-                                        });
+                                        .map(t2 -> mapToResponse(booking, account, schedule, payment, seat, t2.getT1(), t2.getT2(), t2.getT3()));
                             });
                 });
+    }
+
+    private Mono<BookingDto> fetchBooking(Long bookingId, Long accountId) {
+        return bookingServiceWebClient.get()
+                .uri("/booking/api/bookings/bff/{bookingId}", bookingId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Booking not found or unauthorized")))
+                .bodyToMono(BookingDto.class)
+                .filter(booking -> booking.getAccountId().equals(accountId))
+                .switchIfEmpty(Mono.error(new ResourceNotFoundException("Booking not found for the given account")));
+    }
+
+    private Mono<AccountDto> fetchAccount(Long accountId) {
+        return accountServiceWebClient.get()
+                .uri("/account/api/users/{accountId}", accountId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Account not found")))
+                .bodyToMono(AccountDto.class);
+    }
+
+    private Mono<EventScheduleDto> fetchEventSchedule(Long eventScheduleId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/event-schedules/{eventScheduleId}", eventScheduleId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Event schedule not found")))
+                .bodyToMono(EventScheduleDto.class);
+    }
+
+    private Mono<PaymentDto> fetchPayment(Long paymentId) {
+        return paymentServiceWebClient.get()
+                .uri("/payment/api/payments/{paymentId}", paymentId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Payment not found")))
+                .bodyToMono(PaymentDto.class);
+    }
+
+    private Mono<SeatDto> fetchSeat(Long seatId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/seats/{seatId}", seatId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Seat not found")))
+                .bodyToMono(SeatDto.class);
+    }
+
+    private Mono<EventDto> fetchEvent(Long eventId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/bff/events/{eventId}", eventId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Event not found")))
+                .bodyToMono(EventDto.class);
+    }
+
+    private Mono<VenueDto> fetchVenue(Long venueId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/venues/{venueId}", venueId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Venue not found")))
+                .bodyToMono(VenueDto.class);
+    }
+
+    private Mono<SeatClassDto> fetchSeatClass(Long seatClassId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/seat-classes/{seatClassId}", seatClassId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Seat class not found")))
+                .bodyToMono(SeatClassDto.class);
+    }
+
+    private BookingDetailResponse mapToResponse(BookingDto booking, AccountDto account, EventScheduleDto schedule,
+                                                PaymentDto payment, SeatDto seat, EventDto event, VenueDto venue, SeatClassDto seatClass) {
+        return BookingDetailResponse.builder()
+                .bookingId(booking.getBookingId())
+                .status(booking.getStatus().getDisplayValue())
+                .createdAt(booking.getUpdatedAt())
+                .user(BookingDetailResponse.UserInfo.builder().name(account.getName()).build())
+                .event(BookingDetailResponse.EventInfo.builder()
+                        .title(event.getTitle())
+                        .thumbnailUrl(event.getThumbnailUrl())
+                        .eventDate(schedule.getEventDate().toLocalDate().toString())
+                        .venue(BookingDetailResponse.EventInfo.VenueInfo.builder().name(venue.getVenueName()).build())
+                        .build())
+                .seat(BookingDetailResponse.SeatInfo.builder()
+                        .className(seatClass.getClassName())
+                        .floor(seat.getFloor())
+                        .row(seat.getRow())
+                        .col(seat.getCol())
+                        .build())
+                .payment(BookingDetailResponse.PaymentInfo.builder()
+                        .method(payment.getMethod())
+                        .status(payment.getStatus().getDisplayValue())
+                        .paidAt(payment.getUpdatedAt().toString())
+                        .amount(payment.getAmount())
+                        .build())
+                .build();
     }
 }

--- a/src/main/java/com/pyokemon/bff/service/BookingService.java
+++ b/src/main/java/com/pyokemon/bff/service/BookingService.java
@@ -86,7 +86,7 @@ public class BookingService {
                             .eventId(ctx.event().getEventId())
                             .eventTitle(ctx.event().getTitle())
                             .eventDate(ctx.schedule().getEventDate().toLocalDate().toString())
-                            .venueName(ctx.venue().getName())
+                            .venueName(ctx.venue().getVenueName())
                             .thumbnailUrl(ctx.event().getThumbnailUrl())
                             .items(items)
                             .build();

--- a/src/main/java/com/pyokemon/bff/service/MyPageBookingService.java
+++ b/src/main/java/com/pyokemon/bff/service/MyPageBookingService.java
@@ -65,7 +65,7 @@ public class MyPageBookingService {
                                             .bookingId(booking.getBookingId())
                                             .eventTitle(event.getTitle())
                                             .eventDate(formatEventDate(eventSchedule.getEventDate().format(DATE_FORMATTER)))
-                                            .venueName(venue.getName())
+                                            .venueName(venue.getVenueName())
                                             .thumbnailUrl(event.getThumbnailUrl())
                                             .totalPrice(payment.getAmount())
                                             .status(booking.getStatus().getDisplayValue())


### PR DESCRIPTION
## ✏️ 작업 개요  
BookingDetail Webclient 중복호출 및 code refactoring

## 🔨 작업 내용 상세
- BookingDetailResponse의 중첩 DTO들을 Builder 패턴으로 재구성
- name -> venueName 변경
- WebClient 호출 로직을 별도의 private 메서드로 분리

## 🔗 관련 이슈  
- Closes #14 
<img width="1078" height="830" alt="스크린샷 2025-08-20 오후 1 53 39" src="https://github.com/user-attachments/assets/97770e1b-e137-4f1b-a01f-26057279d570" />


## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] Swagger UI에서 API 확인 완료
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수
- [ ] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
