### PR TITLE
Feature/#17/pyokemon 157 예매 내역 조회 paging

### DIFF
--- a/src/main/java/com/pyokemon/bff/controller/MyPageBookingController.java
+++ b/src/main/java/com/pyokemon/bff/controller/MyPageBookingController.java
@@ -1,6 +1,7 @@
 package com.pyokemon.bff.controller;
 
 import com.pyokemon.bff.dto.response.MyPageBookingResponse;
+import com.pyokemon.bff.dto.response.PageResponse;
 import com.pyokemon.bff.service.MyPageBookingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,17 +21,17 @@ public class MyPageBookingController {
 
     /**
      * 사용자 마이페이지 예매 내역 조회
+     * <p>
+     * //     * @param accountId 사용자 ID
      *
-//     * @param accountId 사용자 ID
      * @return 예매 목록
      */
     @GetMapping
-    public Flux<MyPageBookingResponse> getMyBookings(ServerWebExchange exchange, @RequestParam(defaultValue = "0") int page,
-                                                     @RequestParam(defaultValue = "10") int size) {
-        System.out.println(exchange.getRequest().getHeaders().getFirst("x-auth-accountId"));
+    public Mono<PageResponse<MyPageBookingResponse>> getMyBookings(ServerWebExchange exchange, @RequestParam(defaultValue = "0") int page,
+                                                                   @RequestParam(defaultValue = "10") int size) {
         return Mono.justOrEmpty(exchange.getRequest().getHeaders().getFirst("x-auth-accountId"))
                 .switchIfEmpty(Mono.error(new IllegalArgumentException("Missing x-auth-accountId header")))
                 .map(Long::valueOf)
-                .flatMapMany(accountId -> myPageBookingService.getMyBookings(accountId, page, size));
+                .flatMap(accountId -> myPageBookingService.getMyBookings(accountId, page, size));
     }
 }

--- a/src/main/java/com/pyokemon/bff/dto/response/PageResponse.java
+++ b/src/main/java/com/pyokemon/bff/dto/response/PageResponse.java
@@ -1,0 +1,16 @@
+package com.pyokemon.bff.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageResponse<T> {
+    private List<T> content;
+    private int page;
+    private Long totalCount;
+}

--- a/src/main/java/com/pyokemon/bff/service/MyPageBookingService.java
+++ b/src/main/java/com/pyokemon/bff/service/MyPageBookingService.java
@@ -7,8 +7,10 @@ import com.pyokemon.bff.dto.external.EventScheduleDto;
 import com.pyokemon.bff.dto.external.PaymentDto;
 import com.pyokemon.bff.dto.external.VenueDto;
 import com.pyokemon.bff.dto.response.MyPageBookingResponse;
+import com.pyokemon.bff.dto.response.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -16,6 +18,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -34,50 +37,64 @@ public class MyPageBookingService {
      * @return 예매 목록
      */
     @Cacheable(value = "myBookings", key = "#accountId")
-    public Flux<MyPageBookingResponse> getMyBookings(Long accountId, Integer page, Integer size) {
+    public Mono<PageResponse<MyPageBookingResponse>> getMyBookings(Long accountId, Integer page, Integer size) {
         // 1단계: account_id 기준 tb_booking 조회
-        Flux<BookingDto> bookingsFlux = bookingServiceWebClient.get()
+        Mono<PageResponse<BookingDto>> bookingsMono = bookingServiceWebClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/booking/api/bookings/accounts/{accountId}/bookings/order")
                         .queryParam("page", page)
                         .queryParam("size", size)
                         .build(accountId))
                 .retrieve()
-                .bodyToFlux(BookingDto.class);
+                .bodyToMono(new ParameterizedTypeReference<PageResponse<BookingDto>>() {
+                });
 
 
-        // 2단계: 공연/결제 병렬 조회 및 3단계: 공연/공연장 병렬 조회
-        return bookingsFlux.flatMapSequential(booking -> {
-            Mono<PaymentDto> paymentMono = getPayment(booking.getPaymentId());
+//         2단계: 공연/결제 병렬 조회 및 3단계: 공연/공연장 병렬 조회
+        return bookingsMono.flatMap(pageResponse -> {
+            List<BookingDto> bookingList = pageResponse.getContent();
 
-            Mono<EventScheduleDto> eventScheduleMono = getEventSchedule(booking.getEventScheduleId());
+            Flux<MyPageBookingResponse> responses = Flux.fromIterable(bookingList)
 
-            return Mono.zip(paymentMono, eventScheduleMono)
-                    .flatMap(tuple -> {
-                        PaymentDto payment = tuple.getT1();
-                        EventScheduleDto eventSchedule = tuple.getT2();
+                    .flatMapSequential(booking -> {
+                        Mono<PaymentDto> paymentMono = getPayment(booking.getPaymentId());
 
-                        Mono<EventDto> eventMono = getEvent(eventSchedule.getEventId());
-                        Mono<VenueDto> venueMono = getVenue(eventSchedule.getVenueId());
+                        Mono<EventScheduleDto> eventScheduleMono = getEventSchedule(booking.getEventScheduleId());
 
-                        return Mono.zip(eventMono, venueMono)
-                                .map(innerTuple -> {
-                                    EventDto event = innerTuple.getT1();
-                                    VenueDto venue = innerTuple.getT2();
+                        return Mono.zip(paymentMono, eventScheduleMono)
+                                .flatMap(tuple -> {
+                                    PaymentDto payment = tuple.getT1();
+                                    EventScheduleDto eventSchedule = tuple.getT2();
 
-                                    return MyPageBookingResponse.builder()
-                                            .bookingId(booking.getBookingId())
-                                            .eventTitle(event.getTitle())
-                                            .eventDate(formatEventDate(eventSchedule.getEventDate().format(DATE_FORMATTER)))
-                                            .venueName(venue.getVenueName())
-                                            .thumbnailUrl(event.getThumbnailUrl())
-                                            .totalPrice(payment.getAmount())
-                                            .status(booking.getStatus().getDisplayValue())
-                                            .build();
+                                    Mono<EventDto> eventMono = getEvent(eventSchedule.getEventId());
+                                    Mono<VenueDto> venueMono = getVenue(eventSchedule.getVenueId());
+
+                                    return Mono.zip(eventMono, venueMono)
+                                            .map(innerTuple -> {
+                                                EventDto event = innerTuple.getT1();
+                                                VenueDto venue = innerTuple.getT2();
+
+                                                return MyPageBookingResponse.builder()
+                                                        .bookingId(booking.getBookingId())
+                                                        .eventTitle(event.getTitle())
+                                                        .eventDate(formatEventDate(eventSchedule.getEventDate().format(DATE_FORMATTER)))
+                                                        .venueName(venue.getVenueName())
+                                                        .thumbnailUrl(event.getThumbnailUrl())
+                                                        .totalPrice(payment.getAmount())
+                                                        .status(booking.getStatus().getDisplayValue())
+                                                        .build();
+                                            });
                                 });
                     });
+            return responses.collectList()
+                    .map(myPageResponses -> new PageResponse<>(
+                            myPageResponses,
+                            pageResponse.getPage(),
+                            pageResponse.getTotalCount()
+                    ));
         });
     }
+
 
     private Mono<PaymentDto> getPayment(Long paymentId) {
         return paymentServiceWebClient.get()


### PR DESCRIPTION
## ✏️ 작업 개요  
이번 PR에서 작업한 내용을 간단히 요약해주세요.

## 🔨 작업 내용 상세
- PageResponse 생성
- 예매 내역 조회 페이징

## 🔗 관련 이슈  
- Closes #이슈번호
- #17 

## ✅ 체크리스트  



## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
PageResponse 설명
`content` : 응답으로 보낼 데이터
`page` : 현재 페이지 인덱스
`totalCount` : 전체 데이터 수 -> 이게 있어야 프론트에서 페이지수 계산 가능


