### PR TITLE
Pyokemon 163 bff 사용자앱 티켓 상세내역 조회

### DIFF
--- a/src/main/java/com/pyokemon/bff/controller/TicketDetailController.java
+++ b/src/main/java/com/pyokemon/bff/controller/TicketDetailController.java
@@ -1,0 +1,26 @@
+package com.pyokemon.bff.controller;
+
+import com.pyokemon.bff.dto.response.TicketDetailResponse;
+import com.pyokemon.bff.service.TicketDetailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/app/bookings")
+@RequiredArgsConstructor
+public class TicketDetailController {
+
+    private final TicketDetailService ticketDetailService;
+
+    @GetMapping("/my-tickets/{bookingId}")
+    public Mono<TicketDetailResponse> getMyTicketDetail(
+            @PathVariable Long bookingId,
+            @RequestHeader("x-auth-accountId") Long accountId) {
+
+        log.info("Request received for getMyTicketDetail. bookingId: {}, accountId: {}", bookingId, accountId);
+        return ticketDetailService.getBookingDetail(bookingId, accountId);
+    }
+}

--- a/src/main/java/com/pyokemon/bff/dto/external/BookingDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/BookingDto.java
@@ -14,6 +14,7 @@ public class BookingDto {
     private Long bookingId;
     private Long accountId;
     private Long eventScheduleId;
+    private Long tenantId;
     private Long seatId;
     private Long paymentId;
     private BookingStatus status;  // PENDDING, BOOKED, CANCELLED

--- a/src/main/java/com/pyokemon/bff/dto/external/TenantDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/TenantDto.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TenantDto {
     private Long tenantId;
-    private String tenantName;
+    private String name;
 }

--- a/src/main/java/com/pyokemon/bff/dto/external/TenantDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/TenantDto.java
@@ -1,0 +1,13 @@
+package com.pyokemon.bff.dto.external;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TenantDto {
+    private Long tenantId;
+    private String tenantName;
+}

--- a/src/main/java/com/pyokemon/bff/dto/response/BookingDetailResponse.java
+++ b/src/main/java/com/pyokemon/bff/dto/response/BookingDetailResponse.java
@@ -1,6 +1,5 @@
 package com.pyokemon.bff.dto.response;
 
-
 import lombok.Data;
 import lombok.Builder;
 import java.time.LocalDateTime;

--- a/src/main/java/com/pyokemon/bff/dto/response/TicketDetailResponse.java
+++ b/src/main/java/com/pyokemon/bff/dto/response/TicketDetailResponse.java
@@ -1,0 +1,38 @@
+package com.pyokemon.bff.dto.response;
+
+import lombok.Data;
+import lombok.Builder;
+
+@Data
+@Builder
+public class TicketDetailResponse {
+
+    private Long bookingId;
+    private EventInfo event;
+    private SeatInfo seat;
+    private String tenantName;
+
+    @Data
+    @Builder
+    public static class EventInfo {
+        private String title;
+        private String thumbnailUrl;
+        private String eventDate;
+        private VenueInfo venue;
+
+        @Data
+        @Builder
+        public static class VenueInfo {
+            private String name;
+        }
+    }
+
+    @Data
+    @Builder
+    public static class SeatInfo {
+        private String className;
+        private Integer floor;
+        private String row;
+        private String col;
+    }
+}

--- a/src/main/java/com/pyokemon/bff/service/TicketDetailService.java
+++ b/src/main/java/com/pyokemon/bff/service/TicketDetailService.java
@@ -93,7 +93,7 @@ public class TicketDetailService {
 
     private Mono<TenantDto> fetchTenant(Long tenantId) {
         return accountServiceWebClient.get()
-                .uri("/account/api/tenants/{tenantId}", tenantId)
+                .uri("/account/api/bff/tenants/{tenantId}", tenantId)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Tenant not found")))
                 .bodyToMono(TenantDto.class);

--- a/src/main/java/com/pyokemon/bff/service/TicketDetailService.java
+++ b/src/main/java/com/pyokemon/bff/service/TicketDetailService.java
@@ -1,0 +1,162 @@
+package com.pyokemon.bff.service;
+
+import com.pyokemon.bff.dto.response.TicketDetailResponse;
+import com.pyokemon.bff.dto.external.*;
+import com.pyokemon.bff.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple4;
+import reactor.util.function.Tuples;
+
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TicketDetailService {
+
+    private final WebClient bookingServiceWebClient;
+    private final WebClient eventServiceWebClient;
+    private final WebClient accountServiceWebClient;
+
+    // --- 각 단계의 데이터를 담을 내부 record (컨텍스트 객체) ---
+    private record BookingContext(BookingDto booking) {}
+    private record ScheduleInfoContext(BookingDto booking, EventScheduleDto schedule, SeatDto seat, TenantDto tenant) {}
+
+    public Mono<TicketDetailResponse> getBookingDetail(Long bookingId, Long accountId) {
+        log.info("Fetching details for bookingId: {}, accountId: {}", bookingId, accountId);
+
+        // 1단계: 예매 정보 조회 후 컨텍스트에 담기
+        return fetchBooking(bookingId, accountId)
+                .map(BookingContext::new)
+                .flatMap(this::fetchScheduleAndSeatInfo)
+                .flatMap(this::fetchEventAndVenueInfo)
+                .map(this::mapToResponse);
+    }
+
+
+     // 2단계: 공연 일정, 좌석, 테넌트 정보 병렬 조회
+    private Mono<ScheduleInfoContext> fetchScheduleAndSeatInfo(BookingContext ctx) {
+        Mono<EventScheduleDto> scheduleMono = fetchEventSchedule(ctx.booking().getEventScheduleId());
+        Mono<SeatDto> seatMono = fetchSeat(ctx.booking().getSeatId());
+        Mono<TenantDto> tenantMono = fetchTenant(ctx.booking().getTenantId());
+
+        return Mono.zip(scheduleMono, seatMono, tenantMono)
+                .map(tuple -> new ScheduleInfoContext(
+                        ctx.booking(),
+                        tuple.getT1(),
+                        tuple.getT2(),
+                        tuple.getT3()
+                ));
+    }
+
+     // 3단계: 공연, 공연장, 좌석 등급 정보 병렬 조회 후 최종 데이터 조합
+    private Mono<Tuple4<ScheduleInfoContext, EventDto, VenueDto, SeatClassDto>> fetchEventAndVenueInfo(ScheduleInfoContext ctx) {
+        Mono<EventDto> eventMono = fetchEvent(ctx.schedule().getEventId());
+        Mono<VenueDto> venueMono = fetchVenue(ctx.schedule().getVenueId());
+        Mono<SeatClassDto> seatClassMono = fetchSeatClass(ctx.seat().getSeatClassId());
+
+        return Mono.zip(eventMono, venueMono, seatClassMono)
+                .map(tuple -> Tuples.of(ctx, tuple.getT1(), tuple.getT2(), tuple.getT3()));
+    }
+
+
+    private Mono<BookingDto> fetchBooking(Long bookingId, Long accountId) {
+        return bookingServiceWebClient.get()
+                .uri("/booking/api/bookings/bff/{bookingId}", bookingId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Booking not found or unauthorized")))
+                .bodyToMono(BookingDto.class)
+                .filter(booking -> booking.getAccountId().equals(accountId))
+                .switchIfEmpty(Mono.error(new ResourceNotFoundException("Booking not found for the given account")));
+    }
+
+    private Mono<EventScheduleDto> fetchEventSchedule(Long eventScheduleId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/event-schedules/{eventScheduleId}", eventScheduleId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Event schedule not found")))
+                .bodyToMono(EventScheduleDto.class);
+    }
+
+    private Mono<SeatDto> fetchSeat(Long seatId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/seats/{seatId}", seatId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Seat not found")))
+                .bodyToMono(SeatDto.class);
+    }
+
+    private Mono<TenantDto> fetchTenant(Long tenantId) {
+        return accountServiceWebClient.get()
+                .uri("/account/api/tenants/{tenantId}", tenantId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Tenant not found")))
+                .bodyToMono(TenantDto.class);
+    }
+
+    private Mono<EventDto> fetchEvent(Long eventId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/bff/events/{eventId}", eventId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Event not found")))
+                .bodyToMono(EventDto.class);
+    }
+
+    private Mono<VenueDto> fetchVenue(Long venueId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/venues/{venueId}", venueId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Venue not found")))
+                .bodyToMono(VenueDto.class);
+    }
+
+    private Mono<SeatClassDto> fetchSeatClass(Long seatClassId) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/seat-classes/{seatClassId}", seatClassId)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ResourceNotFoundException("Seat class not found")))
+                .bodyToMono(SeatClassDto.class);
+    }
+
+    private TicketDetailResponse mapToResponse(Tuple4<ScheduleInfoContext, EventDto, VenueDto, SeatClassDto> data) {
+        ScheduleInfoContext baseInfo = data.getT1();
+        EventDto event = data.getT2();
+        VenueDto venue = data.getT3();
+        SeatClassDto seatClass = data.getT4();
+
+        BookingDto booking = baseInfo.booking();
+        EventScheduleDto schedule = baseInfo.schedule();
+        SeatDto seat = baseInfo.seat();
+        TenantDto tenant = baseInfo.tenant();
+
+        TicketDetailResponse.EventInfo.VenueInfo venueInfo = TicketDetailResponse.EventInfo.VenueInfo.builder()
+                .name(venue.getVenueName())
+                .build();
+
+        TicketDetailResponse.EventInfo eventInfo = TicketDetailResponse.EventInfo.builder()
+                .title(event.getTitle())
+                .thumbnailUrl(event.getThumbnailUrl())
+                .eventDate(schedule.getEventDate().format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .venue(venueInfo)
+                .build();
+
+        TicketDetailResponse.SeatInfo seatInfo = TicketDetailResponse.SeatInfo.builder()
+                .className(seatClass.getClassName())
+                .floor(seat.getFloor())
+                .row(seat.getRow())
+                .col(seat.getCol())
+                .build();
+
+        return TicketDetailResponse.builder()
+                .bookingId(booking.getBookingId())
+                .event(eventInfo)
+                .seat(seatInfo)
+                .tenantName(tenant.getTenantName())
+                .build();
+    }
+}

--- a/src/main/java/com/pyokemon/bff/service/TicketDetailService.java
+++ b/src/main/java/com/pyokemon/bff/service/TicketDetailService.java
@@ -156,7 +156,7 @@ public class TicketDetailService {
                 .bookingId(booking.getBookingId())
                 .event(eventInfo)
                 .seat(seatInfo)
-                .tenantName(tenant.getTenantName())
+                .tenantName(tenant.getName())
                 .build();
     }
 }


### PR DESCRIPTION
## ✏️ 작업 개요  
사용자앱 티켓 상세내역 조회

## 🔨 작업 내용 상세
-API 엔드포인트 정의: GET /api/app/bookings/my-tickets/{bookingId} 요청을 처리할 컨트롤러와 메소드를 생성
-응답 DTO 설계: 최종 JSON 구조에 맞는 TicketDetailResponse DTO를 생성
-상세 조회 서비스 로직 구현:
1단계: booking-service를 호출하여 예매 정보(eventScheduleId, seatId)를 조회하고, 요청한 사용자가 예매의 소유주가 맞
는지 권한을 검증
2단계: event-service에 병렬 호출을 보내 스케줄(eventDate, eventId, venueId) 및 좌석(floor, row, col, seatClassId)
정보를 가져옴
3단계: 2단계에서 얻은 ID들을 기반으로 event-service에 다시 병렬 호출하여 공연 상세 정보(title, thumbnailUrl,
tenantName), 공연장 이름(venue.name), 좌석 등급명(className)을 가져옴
4단계: 지금까지 가져온 모든 데이터를 최종 TicketDetailResponse DTO로 조합하여 클라이언트에 반환

## 🔗 관련 이슈  
- Closes #이슈번호

## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] Swagger UI에서 API 확인 완료
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수
- [ ] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
<img width="1075" height="816" alt="스크린샷 2025-08-22 오후 4 34 47" src="https://github.com/user-attachments/assets/7a5b4fd1-66ca-4cab-bd5e-bddfcd37e073" />
