### PR TITLE
Pyokemon 183 bff tenant web 최근공연현황조회

### DIFF
--- a/src/main/java/com/pyokemon/bff/controller/TenantDashboardController.java
+++ b/src/main/java/com/pyokemon/bff/controller/TenantDashboardController.java
@@ -1,0 +1,28 @@
+package com.pyokemon.bff.controller;
+
+import com.pyokemon.bff.dto.response.TenantDashboardResponseDto;
+import com.pyokemon.bff.service.TenantDashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/events/tenant")
+@RequiredArgsConstructor
+public class TenantDashboardController {
+
+    private final TenantDashboardService tenantDashboardService;
+
+    @GetMapping("/monthly-summary")
+    public Mono<ResponseEntity<TenantDashboardResponseDto>> getTenantDashboard(
+            @RequestHeader("x-auth-accountId") Long tenantId,
+            @RequestParam("year") int year,
+            @RequestParam("month") int month) {
+
+        return tenantDashboardService.getTenantDashboard(tenantId, year, month)
+                .map(ResponseEntity::ok);
+    }
+}
+
+

--- a/src/main/java/com/pyokemon/bff/dto/external/ActiveEventCountResponseDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/ActiveEventCountResponseDto.java
@@ -1,0 +1,8 @@
+package com.pyokemon.bff.dto.external;
+
+import lombok.Data;
+
+@Data
+public class ActiveEventCountResponseDto {
+    private Long activeEventCount;
+}

--- a/src/main/java/com/pyokemon/bff/dto/external/BookingCountDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/BookingCountDto.java
@@ -1,0 +1,9 @@
+package com.pyokemon.bff.dto.external;
+
+import lombok.Data;
+
+@Data
+public class BookingCountDto {
+    private Long eventScheduleId;
+    private Long ticketCount;
+}

--- a/src/main/java/com/pyokemon/bff/dto/external/IdsRequest.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/IdsRequest.java
@@ -1,0 +1,12 @@
+package com.pyokemon.bff.dto.external;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class IdsRequest {
+    private List<Long> ids;
+}

--- a/src/main/java/com/pyokemon/bff/dto/external/ScheduleDetailDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/ScheduleDetailDto.java
@@ -1,0 +1,12 @@
+package com.pyokemon.bff.dto.external;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class ScheduleDetailDto {
+    private Long eventScheduleId;
+    private String title;
+    private String venueName;
+    private LocalDateTime eventDate;
+}

--- a/src/main/java/com/pyokemon/bff/dto/external/ScheduleIdsResponseDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/ScheduleIdsResponseDto.java
@@ -1,0 +1,9 @@
+package com.pyokemon.bff.dto.external;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class ScheduleIdsResponseDto {
+    private List<Long> scheduleIds;
+}

--- a/src/main/java/com/pyokemon/bff/dto/external/TotalRevenueResponseDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/TotalRevenueResponseDto.java
@@ -1,0 +1,8 @@
+package com.pyokemon.bff.dto.external;
+
+import lombok.Data;
+
+@Data
+public class TotalRevenueResponseDto {
+    private Long totalRevenue;
+}

--- a/src/main/java/com/pyokemon/bff/dto/external/TotalSoldTicketsResponseDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/external/TotalSoldTicketsResponseDto.java
@@ -1,0 +1,8 @@
+package com.pyokemon.bff.dto.external;
+
+import lombok.Data;
+
+@Data
+public class TotalSoldTicketsResponseDto {
+    private Long totalTicketsSold;
+}

--- a/src/main/java/com/pyokemon/bff/dto/response/TenantDashboardResponseDto.java
+++ b/src/main/java/com/pyokemon/bff/dto/response/TenantDashboardResponseDto.java
@@ -1,0 +1,36 @@
+package com.pyokemon.bff.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class TenantDashboardResponseDto {
+    private Data data;
+
+    @Getter
+    @Builder
+    public static class Data {
+        private List<EventItem> events;
+        private Summary summary;
+    }
+
+    @Getter
+    @Builder
+    public static class EventItem {
+        private String title;
+        private String venueName;
+        private LocalDateTime eventDate;
+        private Long ticketCount;
+    }
+
+    @Getter
+    @Builder
+    public static class Summary {
+        private Long totalRevenue;
+        private Long activeEventCount;
+        private Long totalTicketsSold;
+    }
+}

--- a/src/main/java/com/pyokemon/bff/service/TenantDashboardService.java
+++ b/src/main/java/com/pyokemon/bff/service/TenantDashboardService.java
@@ -1,0 +1,147 @@
+package com.pyokemon.bff.service;
+
+import com.pyokemon.bff.dto.external.*;
+import com.pyokemon.bff.dto.response.TenantDashboardResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TenantDashboardService {
+
+    private final WebClient bookingServiceWebClient;
+    private final WebClient eventServiceWebClient;
+    private final WebClient paymentServiceWebClient;
+
+    public Mono<TenantDashboardResponseDto> getTenantDashboard(Long tenantId, int year, int month) {
+
+        // 📌 1단계: event-service에서 기준 ID 목록 확보
+        Mono<List<Long>> scheduleIdsMono = fetchScheduleIdsByTenant(tenantId, year, month);
+
+        return scheduleIdsMono.flatMap(scheduleIds -> {
+
+            // ID 목록이 비어있으면 바로 빈 대시보드 반환
+            if (scheduleIds.isEmpty()) {
+                return Mono.just(createEmptyDashboard());
+            }
+
+            // 📌 2단계: 모든 상세/통계 정보 병렬 조회
+            Mono<List<ScheduleDetailDto>> detailsMono = fetchScheduleDetails(scheduleIds);
+            Mono<List<BookingCountDto>> countsMono = fetchBookingCounts(scheduleIds);
+            Mono<TotalRevenueResponseDto> revenueMono = fetchTotalRevenue(scheduleIds);
+            Mono<TotalSoldTicketsResponseDto> soldTicketsMono = fetchTotalSoldTickets(scheduleIds);
+            Mono<ActiveEventCountResponseDto> activeEventsMono = fetchActiveEventCount(tenantId, year, month);
+
+            return Mono.zip(detailsMono, countsMono, revenueMono, soldTicketsMono, activeEventsMono)
+                    .map(tuple -> {
+                        // 📌 3단계: 최종 데이터 조립
+                        return mapToDashboardResponse(
+                                tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5()
+                        );
+                    });
+        });
+    }
+
+    private Mono<List<Long>> fetchScheduleIdsByTenant(Long tenantId, int year, int month) {
+        return eventServiceWebClient.get()
+                .uri("event/api/events/tenant/schedules-by-tenant?year={y}&month={m}", year, month)
+                .header("x-auth-accountId", tenantId.toString())
+                .retrieve()
+                .bodyToMono(ScheduleIdsResponseDto.class)
+                .map(ScheduleIdsResponseDto::getScheduleIds);
+    }
+
+    private Mono<List<ScheduleDetailDto>> fetchScheduleDetails(List<Long> scheduleIds) {
+        return eventServiceWebClient.post()
+                .uri("/event/api/events/schedules/details/_batch")
+                .bodyValue(new IdsRequest(scheduleIds))
+                .retrieve()
+                .bodyToFlux(ScheduleDetailDto.class)
+                .collectList();
+    }
+
+    private Mono<List<BookingCountDto>> fetchBookingCounts(List<Long> scheduleIds) {
+        String ids = scheduleIds.stream().map(String::valueOf).collect(Collectors.joining(","));
+        return bookingServiceWebClient.get()
+                .uri("/booking/api/bookings/counts?scheduleIds={ids}", ids)
+                .retrieve()
+                .bodyToFlux(BookingCountDto.class)
+                .collectList();
+    }
+
+    private Mono<TotalRevenueResponseDto> fetchTotalRevenue(List<Long> scheduleIds) {
+        String ids = scheduleIds.stream().map(String::valueOf).collect(Collectors.joining(","));
+        return paymentServiceWebClient.get()
+                .uri("/payment/api/payments/summary/revenue?scheduleIds={ids}", ids)
+                .retrieve()
+                .bodyToMono(TotalRevenueResponseDto.class);
+    }
+
+    private Mono<TotalSoldTicketsResponseDto> fetchTotalSoldTickets(List<Long> scheduleIds) {
+        String ids = scheduleIds.stream().map(String::valueOf).collect(Collectors.joining(","));
+        return bookingServiceWebClient.get()
+                .uri("booking/api/bookings/summary/sold-count?scheduleIds={ids}", ids)
+                .retrieve()
+                .bodyToMono(TotalSoldTicketsResponseDto.class);
+    }
+
+    private Mono<ActiveEventCountResponseDto> fetchActiveEventCount(Long tenantId, int year, int month) {
+        return eventServiceWebClient.get()
+                .uri("/event/api/events/tenant/summary/count?year={y}&month={m}", year, month)
+                .header("x-auth-accountId", tenantId.toString())
+                .retrieve()
+                .bodyToMono(ActiveEventCountResponseDto.class);
+    }
+
+    private TenantDashboardResponseDto mapToDashboardResponse(List<ScheduleDetailDto> details, List<BookingCountDto> counts,
+                                                              TotalRevenueResponseDto revenue, TotalSoldTicketsResponseDto soldTickets,
+                                                              ActiveEventCountResponseDto activeEvents) {
+
+        Map<Long, Long> countsMap = counts.stream()
+                .collect(Collectors.toMap(BookingCountDto::getEventScheduleId, BookingCountDto::getTicketCount));
+
+        List<TenantDashboardResponseDto.EventItem> eventItems = details.stream()
+                .map(detail -> TenantDashboardResponseDto.EventItem.builder()
+                        .title(detail.getTitle())
+                        .venueName(detail.getVenueName())
+                        .eventDate(detail.getEventDate())
+                        .ticketCount(countsMap.getOrDefault(detail.getEventScheduleId(), 0L))
+                        .build())
+                .collect(Collectors.toList());
+
+        TenantDashboardResponseDto.Summary summary = TenantDashboardResponseDto.Summary.builder()
+                .totalRevenue(revenue.getTotalRevenue())
+                .totalTicketsSold(soldTickets.getTotalTicketsSold())
+                .activeEventCount(activeEvents.getActiveEventCount())
+                .build();
+
+        return TenantDashboardResponseDto.builder()
+                .data(TenantDashboardResponseDto.Data.builder()
+                        .events(eventItems)
+                        .summary(summary)
+                        .build())
+                .build();
+    }
+
+    private TenantDashboardResponseDto createEmptyDashboard() {
+        return TenantDashboardResponseDto.builder()
+                .data(TenantDashboardResponseDto.Data.builder()
+                        .events(Collections.emptyList())
+                        .summary(TenantDashboardResponseDto.Summary.builder()
+                                .totalRevenue(0L)
+                                .totalTicketsSold(0L)
+                                .activeEventCount(0L)
+                                .build())
+                        .build())
+                .build();
+    }
+
+
+}


### PR DESCRIPTION
## ✏️ 작업 개요  
테넌트(공연 기획사)가 웹 메인 페이지에서 지정된 월의 공연 현황을 한눈에 파악할 수 있는 대시보드 기능을 개발합니다.

이 기능은 최근 공연 목록과 함께 총매출, 총 판매 티켓 수, 활성 공연 수 등의 핵심 지표를 요약하여 제공함으로써, 테넌트가 빠르고 정확한 비즈니스 결정을 내릴 수 있도록 돕습니다.

## 🔨 작업 내용 상세
- BFF: API 엔드포인트 개발 (GET /api/events/tenant/monthly-summary?year=${year}&month=${month})

- BFF: 최종 응답 DTO (DashboardResponseDto) 설계

- BFF: 마이크로서비스 오케스트레이션 로직 구현
         1단계: booking-service에 기준 ID(event_schedule_id 목록) 요청
         2단계: 모든 상세/통계 정보 병렬(Mono.zip) 조회
         3단계: 최종 데이터 조립

## 🔗 관련 이슈  
- Closes #23 

## ✅ 체크리스트  
- [x] 테스트 코드 작성 완료
- [x] 로컬에서 기능 정상 작동 확인
- [x] Swagger UI에서 API 확인 완료
- [x] 예외 처리 및 ResponseDto 적용
- [x] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [x] Google Java Style Guide 및 네이밍 규칙 준수
- [x] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
<img width="1090" height="722" alt="스크린샷 2025-08-26 오후 5 36 29" src="https://github.com/user-attachments/assets/ac7d2d85-9c4d-4a3e-9115-13c5cf2179e2" />